### PR TITLE
Potential fix for code scanning alert no. 1: Disabling Electron webSecurity

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -46,7 +46,7 @@ function createWindow() {
       // See nklayman.github.io/vue-cli-plugin-electron-builder/guide/security.html#node-integration for more info
       nodeIntegration: process.env.ELECTRON_NODE_INTEGRATION,
       spellcheck: false,
-      webSecurity: process.env.NODE_ENV === 'production' ? true : false,
+      webSecurity: true,
       preload: path.join(__dirname, 'preload.js'),
       enableRemoteModule: false,
     }


### PR DESCRIPTION
Potential fix for [https://github.com/annelbcodes/argus/security/code-scanning/1](https://github.com/annelbcodes/argus/security/code-scanning/1)

To fix the issue, we should avoid disabling `webSecurity` entirely. Instead, we can leave it enabled in all environments (including development) to maintain the same-origin policy. If there is a specific need to bypass CORS restrictions during development, we can use other debugging tools or configure a development server to handle cross-origin requests securely.

The fix involves:
1. Removing the conditional logic that disables `webSecurity` in development mode.
2. Ensuring that `webSecurity` is always set to `true` in the `webPreferences` object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
